### PR TITLE
Update setup-ruby action

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -22,11 +22,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
           bundler-cache: true
-          cache-version: 0
       - name: Set up Pages
         id: pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
The previously used version no longer works with the current actions/checkout@v4.